### PR TITLE
Capitalized kedro-viz in Visualise Layers

### DIFF
--- a/docs/source/tutorial/visualise_pipeline.md
+++ b/docs/source/tutorial/visualise_pipeline.md
@@ -74,7 +74,7 @@ regressor:
   layer: models
 ```
 
-Run kedro-viz again with `kedro viz` and observe how your visualisation has changed to indicate the layers:
+Run Kedro-Viz again with `kedro viz` and observe how your visualisation has changed to indicate the layers:
 
 ![](../meta/images/pipeline_visualisation_with_layers.png)
 


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
This is for an issue #1896



## Development notes
<!-- What have you changed, and how has this been tested? -->
`kedro-viz` was capitalised to `Kedro-Viz`

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
